### PR TITLE
Fix backspace and enter not working after committing Chinese text

### DIFF
--- a/mac/Sources/InputController.swift
+++ b/mac/Sources/InputController.swift
@@ -342,7 +342,9 @@ class QBopomofoInputController: IMKInputController {
 
     private func processChewingKey(ctx: OpaquePointer, keyCode: UInt16, chars: String) -> Bool {
         switch keyCode {
-        case 36: chewing_handle_Enter(ctx); return true
+        case 36:
+            if chewing_buffer_Len(ctx) == 0 && chewing_bopomofo_Check(ctx) == 0 { return false }
+            chewing_handle_Enter(ctx); return true
         case 51:
             if chewing_buffer_Len(ctx) == 0 && chewing_bopomofo_Check(ctx) == 0 { return false }
             chewing_handle_Backspace(ctx); return true


### PR DESCRIPTION
## Summary
- 中文輸入送出後，Backspace/Enter 被輸入法吃掉而無法刪除已送出的文字（在 Sublime Text 等編輯器中重現）
- 原因：`processChewingKey()` 中 Backspace/Enter 無條件 `return true`，即使 chewing buffer 為空
- 修正：當 buffer 為空且沒有注音輸入中時，`return false` 讓按鍵事件 pass through 給應用程式

## Test plan
- [ ] 在 Sublime Text 中輸入中文並送出，按 Backspace 確認能正常刪除
- [ ] 輸入注音中按 Backspace 確認仍能正常刪除注音符號
- [ ] 有組字 buffer 時按 Backspace 確認能正常刪除 buffer 內容
- [ ] 在 Sublime Text 中輸入中文並送出，按 Enter 確認能正常換行