### PR TITLE
Add configurable candidate selection keys

### DIFF
--- a/mac/Sources/CandidatePanel.swift
+++ b/mac/Sources/CandidatePanel.swift
@@ -78,6 +78,9 @@ class CandidatePanel: NSPanel {
 
     // MARK: - Public API
 
+    /// 選字鍵標籤（由 InputController 根據偏好設定更新）
+    var selectionKeyLabels: [String] = ["1","2","3","4","5","6","7","8","9","0"]
+
     func setCandidates(_ list: [String], page: Int, totalPages: Int) {
         candidates = list
         highlightedIndex = 0
@@ -135,7 +138,7 @@ class CandidatePanel: NSPanel {
 
         // Build new rows
         for (i, cand) in candidates.enumerated() {
-            let keyLabel = i < 9 ? "\(i + 1)" : ""
+            let keyLabel = i < selectionKeyLabels.count ? selectionKeyLabels[i] : ""
             let row = CandidateRowView(keyLabel: keyLabel, candidate: cand)
             stackView.addArrangedSubview(row)
             row.translatesAutoresizingMaskIntoConstraints = false

--- a/mac/Sources/InputController.swift
+++ b/mac/Sources/InputController.swift
@@ -56,6 +56,9 @@ class QBopomofoInputController: IMKInputController {
 
     private var candidatePanel: CandidatePanel { CandidatePanel.shared }
 
+    /// 選字鍵（從偏好設定載入）
+    private var selectionKeys: [Character] = Array("1234567890")
+
     // MARK: - Lifecycle
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
@@ -114,6 +117,10 @@ class QBopomofoInputController: IMKInputController {
 
         let shiftBehavior = defaults.integer(forKey: "org.qbopomofo.shiftBehavior")
         qb_composing_set_shift_behavior(session, shiftBehavior > 0 ? Int32(shiftBehavior) : 1)
+
+        let selKeysStr = defaults.string(forKey: "org.qbopomofo.selectionKeys") ?? "1234567890"
+        selectionKeys = Array(selKeysStr)
+        candidatePanel.selectionKeyLabels = selectionKeys.map { String($0) }
 
         chewing_set_maxChiSymbolLen(ctx, 20)
         chewing_set_spaceAsSelection(ctx, 1)
@@ -317,10 +324,11 @@ class QBopomofoInputController: IMKInputController {
                 updateClientDisplay(ctx: ctx, session: session, client: client)
                 return true
             default:
-                // Number keys 1-9 select directly
-                if let ch = chars.first, ch >= "1" && ch <= "9" {
-                    let idx = Int(ch.asciiValue! - Character("1").asciiValue!)
-                    selectCandidateAndLog(ctx: ctx, session: session, client: client, index: idx, source: "#\(idx+1)")
+                // Selection keys (configurable: 1234567890 or asdfghjkl;)
+                if let ch = chars.first,
+                   let idx = selectionKeys.firstIndex(of: ch),
+                   idx < candidatePanel.candidates.count {
+                    selectCandidateAndLog(ctx: ctx, session: session, client: client, index: idx, source: "key:\(ch)")
                     return true
                 }
             }

--- a/mac/Sources/PreferencesWindow.swift
+++ b/mac/Sources/PreferencesWindow.swift
@@ -7,7 +7,7 @@ class PreferencesWindow: NSWindow {
 
     private init() {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 340),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -19,9 +19,9 @@ class PreferencesWindow: NSWindow {
     }
 
     private func setupUI() {
-        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 340))
 
-        var y = 250
+        var y = 290
 
         // Title
         let titleLabel = NSTextField(labelWithString: "Q注音 設定")
@@ -59,6 +59,20 @@ class PreferencesWindow: NSWindow {
         contentView.addSubview(shiftPopup)
         y -= 36
 
+        // Selection keys
+        let selLabel = NSTextField(labelWithString: "選字鍵：")
+        selLabel.frame = NSRect(x: 20, y: y, width: 140, height: 22)
+        contentView.addSubview(selLabel)
+
+        let selPopup = NSPopUpButton(frame: NSRect(x: 170, y: y - 2, width: 180, height: 26))
+        selPopup.addItems(withTitles: ["1234567890", "asdfghjkl;"])
+        let currentSel = UserDefaults.standard.string(forKey: "org.qbopomofo.selectionKeys") ?? "1234567890"
+        selPopup.selectItem(withTitle: currentSel)
+        selPopup.target = self
+        selPopup.action = #selector(selectionKeysChanged(_:))
+        contentView.addSubview(selPopup)
+        y -= 36
+
         // CapsLock behavior
         let capsLabel = NSTextField(labelWithString: "CapsLock 行為：")
         capsLabel.frame = NSRect(x: 20, y: y, width: 140, height: 22)
@@ -94,6 +108,13 @@ class PreferencesWindow: NSWindow {
         let value = sender.indexOfSelectedItem + 1 // 1=SmartToggle, 2=Traditional
         UserDefaults.standard.set(value, forKey: "org.qbopomofo.shiftBehavior")
         NotificationCenter.default.post(name: .qbopomofoPreferencesChanged, object: nil)
+    }
+
+    @objc private func selectionKeysChanged(_ sender: NSPopUpButton) {
+        if let title = sender.titleOfSelectedItem {
+            UserDefaults.standard.set(title, forKey: "org.qbopomofo.selectionKeys")
+            NotificationCenter.default.post(name: .qbopomofoPreferencesChanged, object: nil)
+        }
     }
 
     @objc private func capsLockChanged(_ sender: NSPopUpButton) {


### PR DESCRIPTION
## Summary
- 新增偏好設定：選字鍵可選擇 `1234567890`（預設）或 `asdfghjkl;`（home row）
- 候選字面板標籤會根據設定動態顯示對應的按鍵提示
- 設定即時生效，不需重啟輸入法

## Changes
- `InputController.swift`：選字鍵改為動態屬性，從 UserDefaults 載入，候選字模式按鍵處理改用設定的 selectionKeys
- `CandidatePanel.swift`：keyLabel 改為動態讀取 `selectionKeyLabels`
- `PreferencesWindow.swift`：新增「選字鍵」下拉選單

## Test plan
- [ ] 預設 1234567890 選字正常
- [ ] 切換到 asdfghjkl; 後選字正常，面板顯示 a s d f...
- [ ] 切換設定後立即生效，不需重啟