### PR TITLE
Fix candidate panel clipping at screen edges

### DIFF
--- a/mac/Sources/CandidatePanel.swift
+++ b/mac/Sources/CandidatePanel.swift
@@ -108,10 +108,33 @@ class CandidatePanel: NSPanel {
     }
 
     func show(at point: NSPoint) {
-        // Position: point is bottom-left of the cursor in screen coords
-        // We want the panel to appear below the cursor
-        let origin = NSPoint(x: point.x, y: point.y - self.frame.height)
-        self.setFrameOrigin(origin)
+        let panelSize = self.frame.size
+        var x = point.x
+        var y = point.y - panelSize.height
+
+        // Clamp to screen bounds
+        if let screen = NSScreen.main ?? NSScreen.screens.first {
+            let screenFrame = screen.visibleFrame
+
+            // Right edge
+            if x + panelSize.width > screenFrame.maxX {
+                x = screenFrame.maxX - panelSize.width
+            }
+            // Left edge
+            if x < screenFrame.minX {
+                x = screenFrame.minX
+            }
+            // Bottom edge — flip above cursor
+            if y < screenFrame.minY {
+                y = point.y
+            }
+            // Top edge
+            if y + panelSize.height > screenFrame.maxY {
+                y = screenFrame.maxY - panelSize.height
+            }
+        }
+
+        self.setFrameOrigin(NSPoint(x: x, y: y))
         self.orderFront(nil)
     }
 


### PR DESCRIPTION
小問題，現在候選字視窗如果輸入區在螢幕下方，那候選字視窗就會超出螢幕底下，只看得到前面幾個。

## Summary
- 候選字視窗超出螢幕邊緣時自動調整位置
- 右側/左側超出：推回螢幕內
- 下方超出：翻到游標上方顯示
- 上方超出：推到螢幕上緣

## Test plan
- [ ] 在螢幕右下角輸入中文，確認候選字視窗不會超出螢幕
- [ ] 在螢幕底部輸入，確認視窗翻到游標上方
- [ ] 在螢幕中央輸入，確認視窗正常顯示在游標下方