### PR TITLE
Fix composing cursor not following Left/Right arrow keys

### DIFF
--- a/mac/Sources/InputController.swift
+++ b/mac/Sources/InputController.swift
@@ -411,9 +411,34 @@ class QBopomofoInputController: IMKInputController {
         }
 
         if !display.isEmpty {
+            let nsDisplay = display as NSString
+
+            // Compute cursor position in display string (UTF-16 offset for NSRange)
+            let chewingCursor = Int(chewing_cursor_Current(ctx))
+            let chineseUTF16Len = (chinese as NSString).length
+            let bopoUTF16Len = (bopomofo as NSString).length
+            let chineseStart = nsDisplay.length - bopoUTF16Len - chineseUTF16Len
+            // Convert char-based chewing cursor to UTF-16 offset within chinese
+            let clampedCursor = min(chewingCursor, chinese.count)
+            let charIndex = chinese.index(chinese.startIndex, offsetBy: clampedCursor)
+            let cursorUTF16 = chinese[chinese.startIndex..<charIndex].utf16.count
+            let cursorPos = max(0, min(nsDisplay.length, chineseStart + cursorUTF16))
+            dbg("cursor: chewing=\(chewingCursor) cursorPos=\(cursorPos) displayUTF16Len=\(nsDisplay.length) candMode=\(inCandMode)")
+
+            // Build attributed string: thick underline on char at cursor, thin on the rest.
+            let attrStr = NSMutableAttributedString(string: display)
+            let fullRange = NSRange(location: 0, length: nsDisplay.length)
+            attrStr.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: fullRange)
+            attrStr.addAttribute(.markedClauseSegment, value: 0, range: fullRange)
+            // Thick underline on the character at cursor
+            if cursorPos < nsDisplay.length {
+                let cursorCharRange = nsDisplay.rangeOfComposedCharacterSequence(at: cursorPos)
+                attrStr.addAttribute(.underlineStyle, value: NSUnderlineStyle.thick.rawValue, range: cursorCharRange)
+                attrStr.addAttribute(.markedClauseSegment, value: 1, range: cursorCharRange)
+            }
             client.setMarkedText(
-                display,
-                selectionRange: NSRange(location: display.count, length: 0),
+                attrStr,
+                selectionRange: NSRange(location: cursorPos, length: 0),
                 replacementRange: NSRange(location: NSNotFound, length: 0)
             )
         } else {


### PR DESCRIPTION
說明一下，我不確定是不是 mac 的問題，但我在 gui（sublime text）與 cli（iterm2）輸入中文後，組字區的游標在我按左右鍵都不會跟著動，雖然大部分的情況已經肉體記憶不需要眼睛看，但如果打太多字要選字也是很不方便，所以調了一版。

至少這個調整在 chrome、sublime text、iterm2 都可以讓游標在組字區內移動或 highlight 位置。

## Summary
- 組字區游標現在會跟隨左右鍵移動，游標所在字以粗底線標示，其他字為細底線
- 使用 `chewing_cursor_Current` 取得引擎游標位置，在組字和候選字模式下都正確顯示
- 使用 `NSAttributedString` 搭配 `NSUnderlineStyle` thick/thin + `NSMarkedClauseSegment` 分段，確保在各類應用程式中都有明顯的視覺回饋
- 所有 `NSRange` 計算統一使用 UTF-16 offset，搭配 `rangeOfComposedCharacterSequence` 處理組合字元

## Test plan
- [ ] 輸入多個中文字後按左右鍵，確認粗底線跟著移動
- [ ] 移動游標後按下鍵開候選字窗，確認游標位置不變
- [ ] 在 GUI 應用（如 Sublime Text）和 CLI 應用中都測試視覺效果
- [ ] 輸入含 emoji 或特殊符號的內容，確認不會 crash