### PR TITLE
Fix garbled text in terminal emulators during long input

### DIFF
--- a/mac/Sources/InputController.swift
+++ b/mac/Sources/InputController.swift
@@ -402,8 +402,12 @@ class QBopomofoInputController: IMKInputController {
             }
         }
 
-        // Auto-flush: composing display > 20 chars → commit all
-        if !isAutoFlushing && display.count > 20 {
+        // Auto-flush for mixed content only (pure Chinese overflow is handled by the engine's maxChiSymbolLen).
+        // Only flush when no bopomofo is in progress to avoid clearing marked text mid-input,
+        // which causes garbled output in terminal emulators (iTerm2, CLI apps).
+        if !isAutoFlushing && display.count > 20
+            && qb_composing_has_mixed_content(session) != 0
+            && chewing_bopomofo_Check(ctx) == 0 {
             isAutoFlushing = true
             commitAll(ctx: ctx, session: session, client: client, source: "autoFlush")
             isAutoFlushing = false


### PR DESCRIPTION
## Summary
- 在 iTerm2 等終端機中輸入長句時，前面被擠出去的字會出現亂碼（混入未完成的注音按鍵字元）
- 原因：display auto-flush（`display.count > 20`）在注音尚未輸入完成時就觸發 `commitAll`，導致 `setMarkedText("")` 在輸入中途清空組字區。終端機的 IME 實作處理不好這個 marked text 閃爍，產生亂碼
- 修正：純中文的 buffer 溢出已由引擎的 `maxChiSymbolLen` 處理，auto-flush 只在中英混合內容且注音輸入完成時才觸發
- 此問題僅在 iTerm2、CLI 等終端機環境重現，Sublime Text 等 GUI 應用不受影響

## Test plan
- [ ] 在 iTerm2 中輸入超過 20 字的長句（如「如果我想作詞庫管理，你覺得怎樣作比較好？要有簡單的…」），確認擠出去的字不再出現亂碼
- [ ] 在 Sublime Text 中輸入同樣長句，確認行為不變
- [ ] 中英混合輸入超過 20 字，確認 auto-flush 仍能正常觸發