### PR TITLE
Include single-character candidates when selecting within a phrase

### DIFF
--- a/base/engine/src/editor/selection/phrase.rs
+++ b/base/engine/src/editor/selection/phrase.rs
@@ -231,6 +231,21 @@ impl PhraseSelector {
             .lookup(&syllables, self.lookup_strategy)
             .into_iter()
             .collect::<Vec<_>>();
+        // For multi-character phrases, also include single-character candidates
+        // for the character at the cursor position so users can correct individual characters.
+        if self.end - self.begin > 1 {
+            let single_pos = if self.orig < self.end { self.orig } else { self.begin };
+            if let Some(sym) = self.com.symbol(single_pos) {
+                if let Some(syl) = sym.to_syllable() {
+                    let single_candidates = dict.lookup(&[syl], self.lookup_strategy);
+                    candidates.extend(single_candidates.into_iter());
+                    let alt = editor.syl.alt_syllables(syl);
+                    for &alt_syl in alt {
+                        candidates.extend(dict.lookup(&[alt_syl], self.lookup_strategy).into_iter());
+                    }
+                }
+            }
+        }
         if self.end - self.begin == 1 {
             let alt = editor
                 .syl
@@ -245,12 +260,28 @@ impl PhraseSelector {
         candidates.into_iter().map(|ph| ph.into()).collect()
     }
 
+    /// Build interval for the selected phrase.
+    /// For single-character selections from a multi-char range, narrow the interval
+    /// to just the character at the cursor position.
     pub(crate) fn interval(&self, phrase: impl Into<Box<str>>) -> Interval {
-        Interval {
-            start: self.begin,
-            end: self.end,
-            is_phrase: true,
-            text: phrase.into(),
+        let text: Box<str> = phrase.into();
+        let phrase_chars = text.chars().count();
+        let range_len = self.end - self.begin;
+        if phrase_chars < range_len {
+            let start = if self.orig < self.end { self.orig } else { self.begin };
+            Interval {
+                start,
+                end: start + phrase_chars,
+                is_phrase: true,
+                text,
+            }
+        } else {
+            Interval {
+                start: self.begin,
+                end: self.end,
+                is_phrase: true,
+                text,
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

解決在詞組內無法選到單字候選的問題。

### 使用情境

輸入「雖然說不是腹部起」時，引擎自動斷詞把「腹部」綁在一起。當使用者想把「腹」改成「付」（例如實際想打「付不出來」），移動游標到「腹」按 Down 開候選字，原本只會出現「腹部」這個詞組候選，無法選到「付」「復」「腹」等單字。

### 修正內容

- `PhraseSelector::candidates()`：當選取範圍是多字詞組時，額外加入游標所在字的單字候選（含同音字），列在詞組候選之後
- `PhraseSelector::interval()`：當從多字 range 中選了單字候選時，自動縮小替換範圍到游標所在字，避免整個詞組被覆蓋

### 修改前後對比

| | 修改前 | 修改後 |
|--|--------|--------|
| 游標在「腹」按 Down | 只有「腹部」 | 「腹部」+「腹」「復」「付」… |
| 選了單字「付」 | N/A | 只替換「腹」→「付」，「部」不受影響 |

Refs #1

## Test plan
- [ ] 輸入「腹部」，游標移到「腹」，按 Down 確認候選字包含「腹部」詞組和「腹」「復」「付」等單字
- [ ] 選擇單字「付」，確認只有「腹」被替換，「部」保留
- [ ] 選擇詞組「複步」，確認「腹部」整體被替換
- [ ] 單字候選字（`end - begin == 1`）的行為不受影響