### PR TITLE
Add space bar behavior preference

### DIFF
--- a/base/engine/src/editor/mod.rs
+++ b/base/engine/src/editor/mod.rs
@@ -1310,7 +1310,11 @@ impl State for EnteringSyllable {
                                 self.start_entering()
                             }
                         } else {
+                            let syl_str = shared.syl.read().to_string();
                             shared.syl.clear();
+                            for ch in syl_str.chars() {
+                                shared.com.insert(Symbol::Char(ch));
+                            }
                             self.start_entering()
                         }
                     }

--- a/mac/Sources/InputController.swift
+++ b/mac/Sources/InputController.swift
@@ -145,7 +145,7 @@ class QBopomofoInputController: IMKInputController {
         selectionKeys = Array(selKeysStr)
         candidatePanel.selectionKeyLabels = selectionKeys.map { String($0) }
 
-        spaceCycleMax = min(max(defaults.integer(forKey: "org.qbopomofo.spaceCycleCount"), 0), 3)
+        spaceCycleMax = min(max(defaults.integer(forKey: "org.qbopomofo.spaceCycleCount"), -1), 3)
         spaceCycleRemaining = spaceCycleMax
         spaceCycleTargets = []
         spaceCycleStep = 0
@@ -246,8 +246,8 @@ class QBopomofoInputController: IMKInputController {
             guard hasContent else { return false }
             return insertASCIIIntoComposition(npChar, ctx: ctx, session: session, client: client, source: "numpad")
         }
-        if keyCode == 49 && hasContent && !isCandMode && chewing_bopomofo_Check(ctx) == 0 {
-            spaceCycleRemaining = spaceCycleMax
+        if keyCode == 49 && hasContent && !isCandMode && chewing_bopomofo_Check(ctx) == 0 && spaceCycleMax < 0 {
+            spaceCycleRemaining = 0
             spaceCycleTargets = []
             spaceCycleStep = 0
             spaceCycleSavedCursor = nil

--- a/mac/Sources/PreferencesWindow.swift
+++ b/mac/Sources/PreferencesWindow.swift
@@ -92,10 +92,10 @@ class PreferencesWindow: NSWindow {
         cycleLabel.frame = NSRect(x: 20, y: y, width: 140, height: 22)
         contentView.addSubview(cycleLabel)
 
-        let cyclePopup = NSPopUpButton(frame: NSRect(x: 170, y: y - 2, width: 180, height: 26))
-        cyclePopup.addItems(withTitles: ["0（直接開啟候選字）", "1 次", "2 次", "3 次"])
+        let cyclePopup = NSPopUpButton(frame: NSRect(x: 170, y: y - 2, width: 200, height: 26))
+        cyclePopup.addItems(withTitles: ["直接輸出空白", "直接開啟候選字", "選 1 次常用字", "選 2 次常用字", "選 3 次常用字"])
         let currentCycle = UserDefaults.standard.integer(forKey: "org.qbopomofo.spaceCycleCount")
-        cyclePopup.selectItem(at: min(max(currentCycle, 0), 3))
+        cyclePopup.selectItem(at: min(max(currentCycle + 1, 0), 4))
         cyclePopup.target = self
         cyclePopup.action = #selector(spaceCycleCountChanged(_:))
         contentView.addSubview(cyclePopup)
@@ -151,7 +151,7 @@ class PreferencesWindow: NSWindow {
     }
 
     @objc private func spaceCycleCountChanged(_ sender: NSPopUpButton) {
-        UserDefaults.standard.set(sender.indexOfSelectedItem, forKey: "org.qbopomofo.spaceCycleCount")
+        UserDefaults.standard.set(sender.indexOfSelectedItem - 1, forKey: "org.qbopomofo.spaceCycleCount")
         NotificationCenter.default.post(name: .qbopomofoPreferencesChanged, object: nil)
     }
 


### PR DESCRIPTION
## Summary
- 新增空白鍵行為偏好設定選項，讓使用者可以選擇組字區按空白鍵的行為
- `spaceCycleCount = -1`：直接輸出空白（維持目前上游行為）
- `spaceCycleCount = 0`：直接開啟候選字視窗
- `spaceCycleCount = 1-3`：先自動輪替 N 個常用字，再開啟候選字視窗
- 偏好設定 UI 更新為五個選項，標籤更清楚

## Changes
- **InputController.swift**: 允許 `spaceCycleMax` 為 -1，只在 -1 時走「插入空白」路徑，>=0 時交給引擎開候選字或 space cycle 邏輯
- **PreferencesWindow.swift**: 下拉選單新增「直接輸出空白」選項，index 映射調整為 `index - 1`

## Test plan
- [ ] 設定為「直接輸出空白」→ 組字區按空白鍵應插入空白字元
- [ ] 設定為「直接開啟候選字」→ 組字區按空白鍵應直接開選字視窗
- [ ] 設定為「選 1/2/3 次常用字」→ 應先自動替換候選字 N 次再開視窗
- [ ] 切換設定後即時生效（不需重啟）
- [ ] 既有使用者（spaceCycleCount=0）升級後行為對應到「直接開啟候選字」